### PR TITLE
chore: restrict ts types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+npm-debug.log*

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- limit TypeScript's ambient type lookup to Node built-ins
- add basic gitignore for dependencies and build artifacts

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build` *(fails: duplicate identifiers and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_689c5ac3dd688321903725403c5122bf