### PR TITLE
feat: lazy load frontend routes for improved performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+**/node_modules/
+package-lock.json
+**/package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+dist/
+**/dist/
+.env

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import ReferralLandingPage from '@/pages/ReferralLandingPage';
-import ClaimPage from '@/pages/ClaimPage';
-import CashierDashboard from '@/pages/CashierDashboard';
-import ReferrerDashboard from '@/pages/ReferrerDashboard';
+
+// Lazily load pages to reduce initial bundle size and improve performance
+const ReferralLandingPage = lazy(() => import('@/pages/ReferralLandingPage'));
+const ClaimPage = lazy(() => import('@/pages/ClaimPage'));
+const CashierDashboard = lazy(() => import('@/pages/CashierDashboard'));
+const ReferrerDashboard = lazy(() => import('@/pages/ReferrerDashboard'));
 
 function App() {
   return (
@@ -15,22 +17,24 @@ function App() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
-          <Routes>
-            {/* Main referral landing page */}
-            <Route path="/ref/:code" element={<ReferralLandingPage />} />
-            
-            {/* Claim page with timer */}
-            <Route path="/claim/:rewardId" element={<ClaimPage />} />
-            
-            {/* Cashier dashboard */}
-            <Route path="/cashier" element={<CashierDashboard />} />
-            
-            {/* Referrer dashboard (demo) */}
-            <Route path="/" element={<ReferrerDashboard />} />
-            
-            {/* Fallback route */}
-            <Route path="*" element={<ReferrerDashboard />} />
-          </Routes>
+          <Suspense fallback={<div className="flex items-center justify-center py-20">Loading...</div>}>
+            <Routes>
+              {/* Main referral landing page */}
+              <Route path="/ref/:code" element={<ReferralLandingPage />} />
+
+              {/* Claim page with timer */}
+              <Route path="/claim/:rewardId" element={<ClaimPage />} />
+
+              {/* Cashier dashboard */}
+              <Route path="/cashier" element={<CashierDashboard />} />
+
+              {/* Referrer dashboard (demo) */}
+              <Route path="/" element={<ReferrerDashboard />} />
+
+              {/* Fallback route */}
+              <Route path="*" element={<ReferrerDashboard />} />
+            </Routes>
+          </Suspense>
         </motion.div>
       </div>
     </Router>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    // Disable sourcemaps in production for smaller, faster builds
+    sourcemap: false,
   },
 })
 


### PR DESCRIPTION
## Summary
- lazy load React pages and wrap routes with Suspense fallback
- disable sourcemaps in Vite production build to reduce bundle size
- add repository-wide `.gitignore`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails: no tsconfig found)*
- `npm run build` *(fails: no tsconfig found)*

------
https://chatgpt.com/codex/tasks/task_b_689c5af954a88321b0a2a5cb13b7165d