### PR TITLE
feat: avoid s3 when bucket absent

### DIFF
--- a/backend/src/services/s3.service.ts
+++ b/backend/src/services/s3.service.ts
@@ -2,18 +2,23 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { localFileService } from './local-file.service';
 
 export class S3Service {
-  private client: S3Client;
-  private bucketName: string;
+  private client?: S3Client;
+  private bucketName?: string;
   private region: string;
 
   constructor() {
     this.region = process.env.AWS_REGION || 'ap-southeast-1';
-    this.bucketName = process.env.AWS_S3_BUCKET || '';
-    this.client = new S3Client({ region: this.region });
+    this.bucketName = process.env.AWS_S3_BUCKET?.trim();
+
+    if (this.bucketName) {
+      this.client = new S3Client({ region: this.region });
+    } else {
+      console.warn('AWS_S3_BUCKET not configured, using local storage');
+    }
   }
 
   async uploadBuffer(key: string, buffer: Buffer, contentType: string): Promise<string> {
-    if (!this.bucketName) {
+    if (!this.bucketName || !this.client) {
       return localFileService.saveBuffer(key, buffer);
     }
 


### PR DESCRIPTION
## Summary
- avoid initializing S3 client when bucket env var is missing
- fall back to local file storage if no S3 bucket is configured
- log a warning when the bucket is undefined so uploads use local storage

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: spawnSync /workspace/referral-projek/backend/node_modules/esbuild/bin/esbuild EACCES)*
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_689c70fafb8c8321aaf8cc58c6b44b45