### PR TITLE
feat: allow generating codes from referral link

### DIFF
--- a/app/api/code/route.ts
+++ b/app/api/code/route.ts
@@ -1,19 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, requireAuth } from '@/lib/supabase/server';
+import { createServerClientWithRequest } from '@/lib/supabase/server';
 import { generateCodeSchema } from '@/lib/validation';
 import { generateRandomCode, hashCode, generateSalt, calculateExpiryTime } from '@/lib/utils';
 
 // POST /api/code/generate
 export async function POST(request: NextRequest) {
   try {
-    const user = await requireAuth();
+    const supabase = createServerClientWithRequest(request);
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
     const body = await request.json();
-    
+
     // Validate input
     const validatedData = generateCodeSchema.parse(body);
-    
-    const supabase = await createServerClient();
-    
+
     // Verify the user is the referred user
     if (validatedData.referredUserId !== user.id) {
       return NextResponse.json(

--- a/app/r/[slug]/page.tsx
+++ b/app/r/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from 'next/navigation';
+import { createServerClient } from '@/lib/supabase/server';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import CodeGenerator from '@/components/CodeGenerator';
+
+interface Params {
+  slug: string;
+}
+
+export default async function ReferralSlugPage({ params }: { params: Params }) {
+  const supabase = createServerClient();
+  const { data: invite, error } = await supabase
+    .from('invites')
+    .select('id, title, description, is_active')
+    .eq('slug', params.slug)
+    .eq('is_active', true)
+    .single();
+
+  if (error || !invite) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-red-50 to-red-100 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>{invite.title}</CardTitle>
+          {invite.description && <CardDescription>{invite.description}</CardDescription>}
+        </CardHeader>
+        <CardContent>
+          <CodeGenerator inviteId={invite.id} inviteTitle={invite.title} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/CodeGenerator.tsx
+++ b/components/CodeGenerator.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { Button } from '@/components/ui/Button';
+import CountdownTimer from '@/components/ui/CountdownTimer';
+
+interface CodeGeneratorProps {
+  inviteId: string;
+  inviteTitle: string;
+}
+
+export default function CodeGenerator({ inviteId, inviteTitle }: CodeGeneratorProps) {
+  const supabase = createClientComponentClient();
+  const [code, setCode] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const generate = async () => {
+    setLoading(true);
+    setMessage(null);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        setMessage('Please login to generate a code');
+        return;
+      }
+      const res = await fetch('/api/code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inviteId, referredUserId: user.id })
+      });
+      const result = await res.json();
+      if (result.success) {
+        setCode(result.data.code);
+        setExpiresAt(result.data.expiresAt);
+      } else {
+        setMessage(result.error || 'Failed to generate code');
+      }
+    } catch (err) {
+      setMessage('Failed to generate code');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (code) {
+    return (
+      <div className="space-y-4 text-center">
+        <div>
+          <p className="text-sm text-gray-600">Kode untuk {inviteTitle}</p>
+          <p className="text-4xl font-mono font-bold tracking-widest">{code}</p>
+        </div>
+        {expiresAt && (
+          <div className="flex justify-center">
+            <CountdownTimer expiresAt={expiresAt} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center space-y-4">
+      {message && <p className="text-sm text-red-600">{message}</p>}
+      <Button onClick={generate} loading={loading}>
+        Generate Code
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CodeGenerator component to create single-use codes
- show code generation page when visiting a referral link
- ensure code API authenticates via request cookies

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run type-check` *(fails: Cannot find module 'next/server.js' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68a1b0dbb2cc8321ba41061ed9317418