### PR TITLE
feat: add QR code generation and scanning

### DIFF
--- a/app/cashier/page.tsx
+++ b/app/cashier/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
+import dynamic from 'next/dynamic';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { toast } from 'react-hot-toast';
+
+const QrReader = dynamic(async () => (await import('react-qr-reader')).QrReader as any, { ssr: false });
 
 interface RedemptionResult {
   status: 'SUCCESS' | 'INVALID' | 'USED' | 'EXPIRED' | 'INACTIVE';
@@ -21,6 +24,7 @@ export default function CashierPage() {
   const [code, setCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<RedemptionResult | null>(null);
+  const [showScanner, setShowScanner] = useState(false);
 
   const handleRedeem = async () => {
     if (!code.trim()) {
@@ -141,7 +145,7 @@ export default function CashierPage() {
                     disabled={isLoading}
                   />
                 </div>
-                
+
                 <Button
                   onClick={handleRedeem}
                   loading={isLoading}
@@ -151,6 +155,31 @@ export default function CashierPage() {
                 >
                   {isLoading ? 'Verifying...' : 'Redeem Code'}
                 </Button>
+
+                <Button
+                  onClick={() => setShowScanner((prev) => !prev)}
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                >
+                  {showScanner ? 'Close Scanner' : 'Scan QR Code'}
+                </Button>
+
+                {showScanner && (
+                  <div className="mt-4">
+                    <QrReader
+                      constraints={{ facingMode: 'environment' }}
+                      onResult={(result, error) => {
+                        if (!!result) {
+                          const text = result.getText();
+                          setCode(text.toUpperCase());
+                          setShowScanner(false);
+                        }
+                      }}
+                      containerStyle={{ width: '100%' }}
+                    />
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/components/CodeGenerator.tsx
+++ b/components/CodeGenerator.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { Button } from '@/components/ui/Button';
 import CountdownTimer from '@/components/ui/CountdownTimer';
+import { generateQRCodeDataUrl } from '@/lib/utils';
 
 interface CodeGeneratorProps {
   inviteId: string;
@@ -16,6 +17,15 @@ export default function CodeGenerator({ inviteId, inviteTitle }: CodeGeneratorPr
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (code) {
+      generateQRCodeDataUrl(code).then(setQrCodeUrl);
+    } else {
+      setQrCodeUrl(null);
+    }
+  }, [code]);
 
   const generate = async () => {
     setLoading(true);
@@ -52,6 +62,9 @@ export default function CodeGenerator({ inviteId, inviteTitle }: CodeGeneratorPr
           <p className="text-sm text-gray-600">Kode untuk {inviteTitle}</p>
           <p className="text-4xl font-mono font-bold tracking-widest">{code}</p>
         </div>
+        {qrCodeUrl && (
+          <img src={qrCodeUrl} alt={`QR code for ${code}`} className="mx-auto h-40 w-40" />
+        )}
         {expiresAt && (
           <div className="flex justify-center">
             <CountdownTimer expiresAt={expiresAt} />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import bcrypt from 'bcryptjs';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import QRCode from 'qrcode';
 
 // Utility function for combining Tailwind classes
 export function cn(...inputs: ClassValue[]) {
@@ -109,14 +110,13 @@ export function truncateText(text: string, maxLength: number): string {
 }
 
 // Generate QR code data URL
-export function generateQRCodeDataUrl(text: string): string {
-  // This is a placeholder - in production, use a proper QR code library
-  return `data:image/svg+xml;base64,${btoa(`
-    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
-      <rect width="200" height="200" fill="white"/>
-      <text x="100" y="100" text-anchor="middle" fill="black">${text}</text>
-    </svg>
-  `)}`;
+export async function generateQRCodeDataUrl(text: string): Promise<string> {
+  try {
+    return await QRCode.toDataURL(text, { margin: 1 });
+  } catch (error) {
+    console.error('Error generating QR code:', error);
+    return '';
+  }
 }
 
 // Validate email format


### PR DESCRIPTION
## Summary
- generate real QR codes using qrcode library
- show QR codes for generated referral codes
- add camera-based QR scanner for cashiers

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a1b808f364832194dc64a809177df1